### PR TITLE
Add new data source for security groups

### DIFF
--- a/data_source_security_group.go
+++ b/data_source_security_group.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/sky-uk/gonsx"
+	"github.com/sky-uk/gonsx/api/securitygroup"
+)
+
+func dataSourceSecurityGroup() *schema.Resource {
+
+	return &schema.Resource{
+
+		Read: dataSourceSecurityGroupRead,
+
+		Schema: map[string]*schema.Schema{
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scopeid": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "globalroot-0",
+			},
+		},
+	}
+}
+
+func dataSourceSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
+	nsxclient := meta.(*gonsx.NSXClient)
+	getAllAPI := securitygroup.NewGetAll(d.Get("scopeid").(string))
+
+	err := nsxclient.Do(getAllAPI)
+	if err != nil {
+		return err
+	}
+	name := d.Get("name").(string)
+	for _, secGroup := range getAllAPI.GetResponse().SecurityGroups {
+		if secGroup.Name == name {
+			d.SetId(secGroup.ObjectID)
+			return nil
+		}
+	}
+	return fmt.Errorf("Security group %s not found", name)
+}

--- a/provider.go
+++ b/provider.go
@@ -53,6 +53,10 @@ func Provider() terraform.ResourceProvider {
 			"nsx_firewall_exclusion":      resourceFirewallExclusion(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"nsx_security_group": dataSourceSecurityGroup(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }


### PR DESCRIPTION
This add a new data source to find a security group by its name.

### Usage

```hcl
data "nsx_security_group" "test" {
  name = "security-group-name"
  scopeid = "globalroot-0"
}
```

- `name` (**Required**): Name of the security group to find
- `scopeid` (*Optional*, Default: `globalroot-0`): `globalroot-0` or *datacenterId*